### PR TITLE
Fix: proper ad-hoc signing to resolve 'damaged' error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,10 @@ jobs:
           APP_PATH=$(find src-tauri/target/release/bundle/macos -name "*.app" -maxdepth 1 | head -1)
           if [ -n "$APP_PATH" ]; then
             echo "Signing $APP_PATH..."
-            codesign --force --deep -s - "$APP_PATH"
+            codesign --force --sign - "$APP_PATH"
             echo "✅ Ad-hoc signed: $APP_PATH"
+            codesign --verify --deep --strict "$APP_PATH"
+            echo "✅ Signature verified"
           fi
 
       - name: Re-create DMG with signed app
@@ -92,8 +94,10 @@ jobs:
           APP_PATH=$(find src-tauri/target/release/bundle/macos -name "*.app" -maxdepth 1 | head -1)
           if [ -n "$APP_PATH" ]; then
             echo "Signing $APP_PATH..."
-            codesign --force --deep -s - "$APP_PATH"
+            codesign --force --sign - "$APP_PATH"
             echo "✅ Ad-hoc signed: $APP_PATH"
+            codesign --verify --deep --strict "$APP_PATH"
+            echo "✅ Signature verified"
           fi
 
       - name: Re-create DMG with signed app


### PR DESCRIPTION
## Problem
Downloaded app shows **"is damaged and can't be opened"** even after ad-hoc signing in CI.

## Root Cause
`codesign --force --deep -s -` only linker-signed the main binary without sealing the app bundle's resources. The resulting signature was inconsistent:
```
codesign --verify: code has no resources but signature indicates they must be present
```

No `_CodeSignature/CodeResources` directory was created in the .app bundle.

## Fix
- Replace `--deep -s -` with `--sign -` (no `--deep`)
- This properly signs the app bundle and creates sealed resources
- Added `codesign --verify --deep --strict` step to catch signing issues in CI

## After This
Users downloading the DMG will see **"unidentified developer"** instead of **"damaged"** — right-click → Open bypasses Gatekeeper on first launch.