### PR TITLE
Fix: overwrite original DMG with signed app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
           DMG_DIR="src-tauri/target/release/bundle/dmg"
           if [ -n "$APP_PATH" ]; then
             APP_NAME=$(basename "$APP_PATH" .app)
-            DMG_PATH="$DMG_DIR/${APP_NAME}.dmg"
-            rm -f "$DMG_PATH"
-            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_PATH"
-            echo "✅ DMG recreated with signed app: $DMG_PATH"
+            # Remove ALL existing DMGs and recreate with the signed app
+            ORIG_DMG=$(find "$DMG_DIR" -name "*.dmg" | head -1)
+            echo "Original DMG: $ORIG_DMG"
+            rm -f "$DMG_DIR"/*.dmg
+            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$ORIG_DMG"
+            echo "✅ DMG recreated (overwritten) with signed app: $ORIG_DMG"
           fi
 
       - name: Upload macOS bundle artifacts
@@ -106,10 +108,12 @@ jobs:
           DMG_DIR="src-tauri/target/release/bundle/dmg"
           if [ -n "$APP_PATH" ]; then
             APP_NAME=$(basename "$APP_PATH" .app)
-            DMG_PATH="$DMG_DIR/${APP_NAME}.dmg"
-            rm -f "$DMG_PATH"
-            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_PATH"
-            echo "✅ DMG recreated with signed app: $DMG_PATH"
+            # Overwrite the ORIGINAL DMG so tauri-action uploads the signed version
+            ORIG_DMG=$(find "$DMG_DIR" -name "*.dmg" | head -1)
+            echo "Original DMG: $ORIG_DMG"
+            rm -f "$DMG_DIR"/*.dmg
+            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$ORIG_DMG"
+            echo "✅ DMG recreated (overwritten) with signed app: $ORIG_DMG"
           fi
 
       - name: Publish release assets


### PR DESCRIPTION
## Problem
The previous signing fix (#47) correctly signs the `.app` bundle, but **tauri-action uploads the ORIGINAL unsigned DMG** because we were creating the re-signed DMG with a different filename:

- Original (unsigned): `Clipper_0.1.0_aarch64.dmg`
- Re-created (signed): `Clipper.dmg`

tauri-action picks up the original → users still get the unsigned "damaged" build.

## Fix
Find the original DMG path and overwrite it in-place with the signed `.app`, so tauri-action uploads the correct file.

## Verification
After merging + tagging, download the DMG and verify:
```bash
hdiutil attach Clipper_0.1.0_aarch64.dmg -mountpoint /tmp/verify
codesign --verify --deep --strict /tmp/verify/Clipper.app
# Should pass without errors
```