### PR TITLE
Fix: auto-strip quarantine on Homebrew cask install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
           DMG_NAME=$(basename "$DMG_PATH")
           echo "Version: $VERSION | SHA: $SHA | DMG: $DMG_NAME"
 
-          printf 'cask "clipper" do\n  version "%s"\n  sha256 "%s"\n\n  url "https://github.com/jitthing/clipper/releases/download/v#{version}/%s"\n  name "Clipper"\n  desc "Screenshot tool with smart window detection and inline annotations"\n  homepage "https://github.com/jitthing/clipper"\n\n  depends_on macos: ">= :ventura"\n\n  app "Clipper.app"\n\n  zap trash: [\n    "~/Library/Application Support/com.clipper.app",\n    "~/Library/Preferences/com.clipper.app.plist",\n  ]\nend\n' "$VERSION" "$SHA" "$DMG_NAME" > Casks/clipper.rb
+          printf 'cask "clipper" do\n  version "%s"\n  sha256 "%s"\n\n  url "https://github.com/jitthing/clipper/releases/download/v#{version}/%s"\n  name "Clipper"\n  desc "Screenshot tool with smart window detection and inline annotations"\n  homepage "https://github.com/jitthing/clipper"\n\n  depends_on macos: ">= :ventura"\n\n  app "Clipper.app"\n\n  postflight do\n    system_command "/usr/bin/xattr",\n                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Clipper.app"],\n                   sudo: false\n  end\n\n  zap trash: [\n    "~/Library/Application Support/com.clipper.app",\n    "~/Library/Preferences/com.clipper.app.plist",\n  ]\nend\n' "$VERSION" "$SHA" "$DMG_NAME" > Casks/clipper.rb
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/Casks/clipper.rb
+++ b/Casks/clipper.rb
@@ -11,6 +11,12 @@ cask "clipper" do
 
   app "Clipper.app"
 
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Clipper.app"],
+                   sudo: false
+  end
+
   zap trash: [
     "~/Library/Application Support/com.clipper.app",
     "~/Library/Preferences/com.clipper.app.plist",


### PR DESCRIPTION
## Problem
Ad-hoc signed apps trigger macOS Gatekeeper:
> "Apple could not verify Clipper is free of malware"

Users have to manually run `xattr -dr com.apple.quarantine` or right-click → Open.

## Fix
Added `postflight` block to the cask formula that automatically strips `com.apple.quarantine` after install. Also updated the CI cask template so future releases include this.

Users can now just:
```bash
brew tap jitthing/clipper https://github.com/jitthing/clipper --force
brew install --cask clipper
open /Applications/Clipper.app  # works immediately
```

No more manual xattr or right-click workaround needed.